### PR TITLE
Update batteryEmulator.ino

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ The case for the cells has been completed. The case model and stl files are incl
 
 ## Future Plans
 
-Design a board for R50 and maybe a table based charge 
+Find a bms that would fit, or try to talk with bq29312pw that was in the original pack

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
+All credits for this project are for  iam4722202468, I just added R50 support.
+
 # ThinkpadBattery
-Open source Thinkpad T420 battery design
-
-http://beta.aceparent.me/#/battery
-
+Open source Thinkpad T420; R50 battery design
 
 ## What is this?
 
-This is a fully open source T420 laptop battery design. The design uses an attiny85, which can reply to the T420 motherboard's SMBUS requests.
+This is a fully open source T420 and R50 laptop battery design. The design uses an attiny85, which can reply to the T420 motherboard's SMBUS requests.
 
 ## Setup
 
@@ -19,9 +18,9 @@ This is a fully open source T420 laptop battery design. The design uses an attin
 ### Creating your own
 
 Parts Needed
-- Arduino Uno (for programming the attiny85)
+- Arduino Uno/Mega  (for programming the attiny85, Mega needs different pin assignment)
 - 12v Lithium-Ion battery pack
-- 3S Lithium-Ion BMS
+- 3S Lithium-Ion BMS (it might be possible to use the existing bms if specification is available but communication needs to be implemented)
 - Components from schematic
 - PCB from schematic
 
@@ -48,11 +47,11 @@ Currently remaining battery %'s aren't exact because I'm assuming there is a lin
 By design, the MCU will always be on as long as a battery is connected to it. This can cause the battery to slowly run out of power if it isn't connected to a laptop. A potential fix could be to implement a low power mode for the attiny, or have a seperate disconnect switch for the battery power on the battery pack itself.
 
 
-### 3D Printable Case
+### 3D Printable Case for T420 only
 
 The case for the cells has been completed. The case model and stl files are included in /model
 
 
 ## Future Plans
 
-I’m going to make a controller board with a LTC2944 Battery Gas Gauge.
+Design a board for R50 and maybe a table based charge 

--- a/batteryEmulator.ino
+++ b/batteryEmulator.ino
@@ -89,6 +89,24 @@ byte reply0x1A(byte *buff) {
   return 1;
 }
 
+byte reply0x01(byte *buff) {
+  buff[0] = 44;
+  buff[1] = 1;
+  return 2;
+}
+
+byte reply0x02(byte *buff) {
+  buff[0] = 30;
+  buff[1] = 0;
+  return 2;
+}
+
+byte reply0x04(byte *buff) {
+  buff[0] = 0;
+  buff[1] = 0;
+  return 2;
+}
+
 byte reply0x00(byte *buff) {
   buff[0] = 24;
   buff[1] = 0;
@@ -287,8 +305,34 @@ byte reply0x3B(byte *buff) {
 }
 
 byte reply0x09(byte *buff) {
-  buff[0] = 79;
-  buff[1] = 48;
+  //buff[0] = 79;
+  //buff[1] = 48;
+
+ int lower, higher;
+
+  float r1 = 9.89;
+  float r2 = 3.39;
+
+  //float sensorLow = V_LOW * (r2/(r1+r2));
+  //float sensorHigh = V_HIGH * (r2/(r1+r2));
+
+  // Assume linear voltage -> battery capacity coorelation (this isn't perfect)
+  //float m = 1/(sensorHigh - sensorLow);
+  //float b = -sensorLow*m;
+
+  float voltageIn = analogRead(3) * (3.33 / 1024.0);
+  float vin = voltageIn / (r2/(r1+r2)); 
+  int Vinoff = vin * 1000;
+  //int batteryVoltage = (m*voltageIn + b)*BATTERY_CAPACITY;
+
+  if (vin < 0)
+    vin = 0;
+
+  splitNum(Vinoff, &lower, &higher);
+  buff[0] = lower;
+  buff[1] = higher;
+
+
 
   return 2;
 }
@@ -296,8 +340,8 @@ byte reply0x09(byte *buff) {
 byte reply0x0F(byte *buff) {
   int lower, higher;
 
-  float r1 = 9.1;
-  float r2 = 3.0;
+  float r1 = 9.89;
+  float r2 = 3.39;
 
   float sensorLow = V_LOW * (r2/(r1+r2));
   float sensorHigh = V_HIGH * (r2/(r1+r2));
@@ -306,7 +350,7 @@ byte reply0x0F(byte *buff) {
   float m = 1/(sensorHigh - sensorLow);
   float b = -sensorLow*m;
 
-  float voltageIn = analogRead(3) * (3.33 / 1023.0);
+  float voltageIn = analogRead(3) * (3.33 / 1024.0);
   int batteryVoltage = (m*voltageIn + b)*BATTERY_CAPACITY;
 
   if (batteryVoltage < 0)
@@ -445,10 +489,10 @@ byte reply0x06(byte *buff) {
 
 byte (* funMap [])(byte*) = {
   reply0x00,
-  NULL,
-  NULL,
+  reply0x01,
+  reply0x02,
   reply0x03,
-  NULL,
+  reply0x04,
   NULL,
   reply0x06,
   NULL,


### PR DESCRIPTION
Added R50 support, new commands 0x01, 0x02, 0x04 with default values but can be adjusted as needed. Also voltage reported is now actual not hardcoded. 

![178735694_4026888877378332_5953758628131826509_n](https://user-images.githubusercontent.com/82766766/116010485-8033af80-a61f-11eb-8f6a-18d031df2885.jpg)
![177020340_1416134938734538_4463594921853125654_n](https://user-images.githubusercontent.com/82766766/116010488-82960980-a61f-11eb-9b98-f9a321e9c6e3.jpg)
